### PR TITLE
Escape `\` in cotlet_utils.py

### DIFF
--- a/Utils/phonemize/cotlet_utils.py
+++ b/Utils/phonemize/cotlet_utils.py
@@ -446,7 +446,7 @@ def replace_chars_2(text, mapping=roma_mapper_plus_2):
 
 
 def replace_tashdid_2(s):
-    vowels = 'aiueoɯ0123456789.?!_。؟？！．．．＠@＃#＄$％%＾^＆&＊*（)(）_+=[「」]></\`~～―ー∺"'
+    vowels = 'aiueoɯ0123456789.?!_。؟？！．．．＠@＃#＄$％%＾^＆&＊*（)(）_+=[「」]></\\`~～―ー∺"'
     result = []
     
     i = 0


### PR DESCRIPTION
```
/Utils/phonemize/cotlet_utils.py:451: SyntaxWarning: invalid escape sequence '\`'
```
The new line at the end is due to me editing in the browser.