### PR TITLE
Use torch<2.6 until xlstm is updated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pyyaml
 nltk
 matplotlib
 unidic-lite
+torch<2.6
 xlstm
 fugashi
 cutlet


### PR DESCRIPTION
The way https://github.com/NX-AI/xlstm/issues/66 detects CUDA paths no longer works since `torch` 2.6, so stay on an older version for now. 